### PR TITLE
Improve jenkins url support

### DIFF
--- a/internal/jenkins/main.go
+++ b/internal/jenkins/main.go
@@ -40,7 +40,11 @@ func (j JenkinsClient) GetJobNameAndNumberFromURL(u string) (name string, buildN
 			if i+1 == len(folderPathParts) {
 				continue
 			}
-			name += folder + "/"
+			decodedFolder, err := url.QueryUnescape(folder)
+			if err != nil {
+				return "", 0, err
+			}
+			name += decodedFolder + "/"
 		}
 	}
 

--- a/internal/jenkins/main_test.go
+++ b/internal/jenkins/main_test.go
@@ -85,8 +85,8 @@ func TestGetJobNameAndNumberFromURL(t *testing.T) {
 		},
 		{
 			name:            "parses URL with job within multiple folders",
-			input:           "https://jenkins.example.com/job/ansible/job/linux/job/setup/456",
-			wantName:        "ansible/linux/setup",
+			input:           "https://jenkins.example.com/job/old%20ansible/job/linux/job/setup/456",
+			wantName:        "old ansible/linux/setup",
 			wantBuildNumber: 456,
 			wantErr:         false,
 		},
@@ -177,7 +177,7 @@ func TestGetBuildLogs(t *testing.T) {
 
 	t.Run("handles jenkins folder paths correctly", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/job/ansible/job/linux/job/my-job/123/consoleText" {
+			if r.URL.Path != "/job/old ansible/job/linux/job/my-job/123/consoleText" {
 				t.Fatalf("unexpected path: %s", r.URL.Path)
 			}
 
@@ -188,7 +188,7 @@ func TestGetBuildLogs(t *testing.T) {
 
 		client := JenkinsClient{URL: server.URL, Username: "u", Password: "p"}
 
-		reader, err := client.GetBuildLogs("ansible/linux/my-job", 123)
+		reader, err := client.GetBuildLogs("old ansible/linux/my-job", 123)
 		if err != nil {
 			t.Fatalf("GetBuildLogs returned error: %v", err)
 		}


### PR DESCRIPTION
This pull request improves support for Jenkins jobs that are organized within folder paths.

**Jenkins job folder support:**
* Updated `IsJobURL` and `GetJobNameAndNumberFromURL` methods in `internal/jenkins/main.go` to correctly handle Jenkins URLs with folder paths, including jobs nested within multiple folders.
* Modified `GetBuildLogsWithContext` in `internal/jenkins/main.go` to construct job log URLs by iterating through each folder in the job name, ensuring accurate path generation for jobs inside folders.

**Test coverage improvements:**
* Enhanced `TestIsJobURL` in `internal/jenkins/main_test.go` to include cases for Jenkins URLs with path prefixes and trailing slashes, validating the new URL handling logic.
* Added tests to `TestGetJobNameAndNumberFromURL` in `internal/jenkins/main_test.go` to verify correct parsing of job names and build numbers for jobs within multiple folders.
* Introduced a new test in `TestGetBuildLogs` in `internal/jenkins/main_test.go` to confirm that log retrieval works for jobs located within folder paths.