### PR TITLE
add max lines per pattern

### DIFF
--- a/pkg/logparser/main.go
+++ b/pkg/logparser/main.go
@@ -166,22 +166,35 @@ func (lp LogParser) ParseFromSource(source LogSource) ([]*ParseMatch, Stats, err
 // Parse scans a log stream line by line and returns all completed matches.
 func (lp LogParser) Parse(r io.ReadCloser) ([]*ParseMatch, Stats, error) {
 	ctx, cancel := context.WithCancel(lp.ctx)
+
+	// activeMatchers holds all matchers that are currently running and have not yet completed.
+	activeMatchers := []*parseMatchCandidate{}
+
 	// Close the reader when we're done parsing, and cancel the context to stop any ongoing matcher goroutines.
-	defer func() { _ = r.Close() }()
+	defer func() {
+		_ = r.Close()
+		// Close all matcher channels to signal them to stop, and wait for them to finish.
+		for _, m := range activeMatchers {
+			close(m.LineChannel)
+		}
+		for _, m := range activeMatchers {
+			select {
+			case <-m.DoneChannel:
+			case <-time.After(5 * time.Second):
+				lp.logger.Error("matcher did not exit in time", slog.String("rule", m.Rule.Name))
+			}
+		}
+	}()
 	defer cancel()
 
 	stats := Stats{}
 	reader := bufio.NewReaderSize(r, lp.MaxLineSizeKB*1024)
 
-	// activeMatchers holds all matchers that are currently running and have not yet completed.
-	activeMatchers := []*parseMatchCandidate{}
 	matches := []*ParseMatch{}
 
 	// matchChan is used to receive completed matches from the matcher goroutines.
 	matchChan := make(chan *ParseMatch, 100)
 	defer close(matchChan)
-
-	var rtnErr error = nil
 
 	lineNo := 0
 	for {
@@ -197,16 +210,12 @@ func (lp LogParser) Parse(r io.ReadCloser) ([]*ParseMatch, Stats, error) {
 			// Discard the rest of the line
 			_, err := reader.ReadString('\n')
 			if err != nil && err != io.EOF && err != bufio.ErrBufferFull {
-				rtnErr = fmt.Errorf("reader error: %w \n Log line number: %v", err, lineNo)
-				cancel()
-				break
+				return nil, stats, fmt.Errorf("reader error: %w \n Log line number: %v", err, lineNo)
 			}
 			continue
 
 		} else if err != nil && err != io.EOF {
-			rtnErr = fmt.Errorf("reader error: %w \n Log line number: %v", err, lineNo)
-			cancel()
-			break
+			return nil, stats, fmt.Errorf("reader error: %w \n Log line number: %v", err, lineNo)
 		}
 
 		line := &LogLine{
@@ -237,7 +246,11 @@ func (lp LogParser) Parse(r io.ReadCloser) ([]*ParseMatch, Stats, error) {
 
 	// Wait for any remaining matchers to finish
 	for _, m := range activeMatchers {
-		<-m.DoneChannel
+		select {
+		case <-m.DoneChannel:
+		case <-time.After(5 * time.Second):
+			lp.logger.Error("matcher did not exit in time", slog.String("rule", m.Rule.Name))
+		}
 	}
 	matches = append(matches, getNewParseMatches(matchChan)...)
 
@@ -249,5 +262,9 @@ func (lp LogParser) Parse(r io.ReadCloser) ([]*ParseMatch, Stats, error) {
 		matches = matches[:lp.MaxMatches]
 	}
 
-	return matches, stats, rtnErr
+	if ctx.Err() != nil && len(matches) == 0 {
+		return matches, stats, fmt.Errorf("parsing cancelled: %w", ctx.Err())
+	}
+
+	return matches, stats, nil
 }

--- a/pkg/logparser/parser.go
+++ b/pkg/logparser/parser.go
@@ -110,6 +110,11 @@ func runMatchCandidate(ctx context.Context, m *parseMatchCandidate, mc chan *Par
 	matchedLines := []*LogLine{m.FirstLine}
 	checkIndex := 1 // Already matched the first line
 
+	// Determine the initial maximum line number to check based on the first check's MaxLines or the rule's MaxLines
+	runningMaxLine := m.FinalLineNumber
+	if checkIndex < len(m.Rule.Checks) && m.Rule.Checks[checkIndex].MaxLines > 0 {
+		runningMaxLine = m.FirstLine.LineNumber + m.Rule.Checks[checkIndex].MaxLines
+	}
 	for {
 		if checkIndex >= len(m.Rule.Checks) {
 			mc <- &ParseMatch{
@@ -117,22 +122,26 @@ func runMatchCandidate(ctx context.Context, m *parseMatchCandidate, mc chan *Par
 				MatchedLines: matchedLines,
 			}
 			return
-		} else if matchedLines[len(matchedLines)-1].LineNumber >= m.FinalLineNumber {
-			return // The last line checked was the final line to check, no matches found
 		}
 		select {
 		case line, ok := <-m.LineChannel:
 			if !ok {
-				return // Channel has closed
+				return // Channel has closed and there are no more lines to check
 			}
 			matchedLines = append(matchedLines, line)
 
 			if m.Rule.Checks[checkIndex].CheckLine(line.Content) {
 				checkIndex++
+				if checkIndex < len(m.Rule.Checks) && m.Rule.Checks[checkIndex].MaxLines > 0 {
+					runningMaxLine = line.LineNumber + m.Rule.Checks[checkIndex].MaxLines
+				} else {
+					runningMaxLine = m.FinalLineNumber
+				}
+			} else if line.LineNumber >= runningMaxLine {
+				return
 			}
 		case <-ctx.Done():
 			return
 		}
-
 	}
 }

--- a/pkg/logparser/parser_test.go
+++ b/pkg/logparser/parser_test.go
@@ -289,7 +289,6 @@ func TestRunMatcher_HandlesNoMatch(t *testing.T) {
 
 		select {
 		case <-m.DoneChannel:
-			t.Fatal("Unexpected parse match")
 		case <-time.After(100 * time.Millisecond):
 			t.Fatal("RunMatcher did not exit in time")
 		}

--- a/pkg/logparser/parser_test.go
+++ b/pkg/logparser/parser_test.go
@@ -207,7 +207,7 @@ func TestRunMatcher_HandlesMatchAndExit(t *testing.T) {
 		} else if msg.MatchedLines[0] != &firstLog {
 			t.Fatalf("Expected log: %v instead got %v", firstLog.Content, msg.MatchedLines[0].Content)
 		} else if msg.MatchedLines[len(msg.MatchedLines)-1] != &finalLog {
-			t.Fatalf("Expected log: %v instead got %v", firstLog.Content, msg.MatchedLines[len(msg.MatchedLines)-1].Content)
+			t.Fatalf("Expected log: %v instead got %v", finalLog.Content, msg.MatchedLines[len(msg.MatchedLines)-1].Content)
 		} else if msg.Rule != &Rule {
 			t.Fatal("ParseMatch Rule doesn't match Rule")
 		}
@@ -224,33 +224,81 @@ func TestRunMatcher_HandlesMatchAndExit(t *testing.T) {
 }
 
 func TestRunMatcher_HandlesNoMatch(t *testing.T) {
-	Rule := MatchRule{Checks: []LineCheck{{Contains: "match"}, {Contains: "definitely an error"}}, MaxLines: 100}
-	firstLog := LogLine{LineNumber: 1, Content: "match"}
-	m := createMatchCandidate(&firstLog, &Rule)
+	t.Run("handle maxlines for rule", func(t *testing.T) {
+		Rule := MatchRule{Checks: []LineCheck{{Contains: "match"}, {Contains: "definitely an error"}}, MaxLines: 10}
+		firstLog := LogLine{LineNumber: 1, Content: "match"}
+		m := createMatchCandidate(&firstLog, &Rule)
 
-	ctx := t.Context()
-	matchChan := make(chan *ParseMatch)
+		ctx := t.Context()
+		matchChan := make(chan *ParseMatch)
 
-	go runMatchCandidate(ctx, m, matchChan)
+		go runMatchCandidate(ctx, m, matchChan)
 
-	// Spam some non matching lines
-	for i := range 99 {
-		m.LineChannel <- &LogLine{
-			LineNumber: i + 2,
-			Content:    "This won't match the Rules and is there for fun",
+		// Spam some non matching lines
+		for i := range 9 {
+			m.LineChannel <- &LogLine{
+				LineNumber: i + 2,
+				Content:    "This won't match the Rules and is there for fun",
+			}
 		}
-	}
 
-	select {
-	case <-m.DoneChannel:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("RunMatcher did not exit in time")
-	}
+		select {
+		case <-m.DoneChannel:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("RunMatcher did not exit in time")
+		}
 
-	select {
-	case msg := <-matchChan:
-		t.Fatalf("Unexpected parse match: %+v", msg)
-	default:
-		// No message as expected
-	}
+		select {
+		case msg := <-matchChan:
+			t.Fatalf("Unexpected parse match: %+v", msg)
+		default:
+			// No message as expected
+		}
+	})
+
+	t.Run("handle line check maxlines", func(t *testing.T) {
+		Rule := MatchRule{Checks: []LineCheck{{Contains: "match"}, {Contains: "definitely an error", MaxLines: 1}}, MaxLines: 15}
+		firstLog := LogLine{LineNumber: 1, Content: "match"}
+		m := createMatchCandidate(&firstLog, &Rule)
+
+		ctx := t.Context()
+		matchChan := make(chan *ParseMatch, 1) // Buffer of 1 to ensure that if an unexpected match is sent, it doesn't block the test from finishing
+
+		go runMatchCandidate(ctx, m, matchChan)
+
+		// Spam some non matching lines
+		for i := range 8 {
+			m.LineChannel <- &LogLine{
+				LineNumber: i + 2,
+				Content:    "This won't match the Rules and is there for fun",
+			}
+		}
+
+		// This line matches the second check but is outside of the maxlines for that check
+		m.LineChannel <- &LogLine{
+			LineNumber: 10,
+			Content:    "definitely an error",
+		}
+
+		for i := range 5 {
+			m.LineChannel <- &LogLine{
+				LineNumber: i + 11,
+				Content:    "This won't match the Rules and is there for fun",
+			}
+		}
+
+		select {
+		case <-m.DoneChannel:
+			t.Fatal("Unexpected parse match")
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("RunMatcher did not exit in time")
+		}
+
+		select {
+		case msg := <-matchChan:
+			t.Fatalf("Unexpected parse match: %+v", msg)
+		default:
+			// No message as expected
+		}
+	})
 }

--- a/pkg/logparser/rules.go
+++ b/pkg/logparser/rules.go
@@ -7,9 +7,18 @@ import (
 
 // LineCheck defines a single line condition using contains and/or regex.
 type LineCheck struct {
-	Contains  string         `json:"contains"`
-	RegexText string         `mapstructure:"regex" json:"regex"`
-	Regex     *regexp.Regexp `mapstructure:"-" json:"-"`
+	// Contains is a simple substring that must be present in the line for it to match. Optional.
+	Contains string `json:"contains"`
+
+	// RegexText is a regular expression pattern that the line must match. Optional. If both Contains and RegexText are provided, then both conditions must be satisfied for the line to match.
+	RegexText string `mapstructure:"regex" json:"regex"`
+	// Regex is the compiled regular expression. This is not set directly in the config, but is populated when the config is loaded and the regex patterns are compiled.
+	Regex *regexp.Regexp `mapstructure:"-" json:"-"`
+
+	// MaxLines is the maximum number of lines since the last check was satisfied that this check should be considered a match.
+	// E.g. if MaxLines is 5, and this check is the second check in a rule, then this check will be considered satisfied if it matches a line that is within 5 lines of the last line that satisfied the first check in the rule.
+	// Optional. If not set, then there is no limit on the number of lines between checks.
+	MaxLines int `mapstructure:"maxlines" json:"maxLines"`
 }
 
 // MatchRule defines an ordered set of checks and metadata for a log match.


### PR DESCRIPTION
- **Add MaxLines field to LineCheck struct for line matching limits**
- **Add tests for handling MaxLines in RunMatcher**
- **Refactored runMatchCandidate to support maxlines on a per pattern level**
- **Improve error and timeout in Parse function**
