### PR TITLE
LP adding parsing pacing

### DIFF
--- a/pkg/logparser/main.go
+++ b/pkg/logparser/main.go
@@ -175,7 +175,9 @@ func (lp LogParser) Parse(r io.ReadCloser) ([]*ParseMatch, Stats, error) {
 		_ = r.Close()
 		// Close all matcher channels to signal them to stop, and wait for them to finish.
 		for _, m := range activeMatchers {
-			close(m.LineChannel)
+			if m.AcceptingLines {
+				close(m.LineChannel)
+			}
 		}
 		for _, m := range activeMatchers {
 			select {
@@ -234,10 +236,22 @@ func (lp LogParser) Parse(r io.ReadCloser) ([]*ParseMatch, Stats, error) {
 		stats.PartialMatches = stats.PartialMatches + len(pendingMatchers)
 
 		activeMatchers = append(activeMatchers, pendingMatchers...)
+
+		// Wait for any matchers that are no longer accepting lines to finish and collect their matches.
+		for _, m := range activeMatchers {
+			if !m.AcceptingLines {
+				select {
+				case <-m.DoneChannel:
+				case <-time.After(5 * time.Second):
+					lp.logger.Error("matcher did not exit in time", slog.String("rule", m.Rule.Name))
+				}
+			}
+		}
+
 		newMatches := getNewParseMatches(matchChan)
 		if len(newMatches) > 0 {
 			matches = append(matches, newMatches...)
-			if len(matches) > lp.MaxMatches {
+			if len(matches) >= lp.MaxMatches {
 				cancel()
 				break
 			}

--- a/pkg/logparser/main.go
+++ b/pkg/logparser/main.go
@@ -223,7 +223,7 @@ func (lp LogParser) Parse(r io.ReadCloser) ([]*ParseMatch, Stats, error) {
 			LineNumber: lineNo,
 		}
 
-		activeMatchers = purgeInactiveMatchCandidates(lineNo, activeMatchers)
+		activeMatchers = purgeInactiveMatchCandidates(activeMatchers)
 		broadcastLogLine(line, activeMatchers)
 
 		pendingMatchers := matchLineAgainstFirstChecks(line, lp.Rules)

--- a/pkg/logparser/main_test.go
+++ b/pkg/logparser/main_test.go
@@ -3,6 +3,7 @@ package logparser
 import (
 	"errors"
 	"io"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -234,6 +235,46 @@ func TestParse(t *testing.T) {
 
 		if len(matches) != 0 {
 			t.Fatalf("Expected 0 matches, got %d", len(matches))
+		}
+	})
+
+	t.Run("doesn't read more lines than necessary", func(t *testing.T) {
+		// This test checks that the parser effiently parses even when running on a single core by ensuring that it blocks processing more lines
+		// once a match candidate has been sent all it's lines, as at this point it should be able to parse the lines it's been sent.
+		// otherwise it will read through all the lines before processing any matches, which is inefficient.
+
+		// Set the test to run on 1 core to increase the likelihood of this test catching inefficiencies in the parser.
+		runtime.GOMAXPROCS(1)
+		defer runtime.GOMAXPROCS(runtime.NumCPU())
+
+		matching := strings.Repeat("match line \n double line \n", 2)
+		notMatching := strings.Repeat("test line\n", 100)
+
+		reader := io.NopCloser(strings.NewReader(matching + notMatching))
+
+		rule := &MatchRule{
+			Checks: []LineCheck{
+				{Contains: "match line"},
+				{Contains: "double line"},
+			},
+			MaxLines: 2,
+		}
+
+		parser := NewLogParser(
+			WithRules([]*MatchRule{rule}),
+			WithMaxMatches(2),
+		)
+		matches, stats, err := parser.Parse(reader)
+		if err != nil {
+			t.Fatalf("Parse returned error: %v", err)
+		}
+
+		if stats.LinesParsed > 4 {
+			t.Fatalf("Expected early exit, parsed %d lines", stats.LinesParsed)
+		}
+
+		if len(matches) != 2 {
+			t.Fatalf("Expected 2 matches to be collected, got %d", len(matches))
 		}
 	})
 

--- a/pkg/logparser/main_test.go
+++ b/pkg/logparser/main_test.go
@@ -269,7 +269,7 @@ func TestParse(t *testing.T) {
 			t.Fatalf("Parse returned error: %v", err)
 		}
 
-		if stats.LinesParsed > 4 {
+		if stats.LinesParsed > 5 {
 			t.Fatalf("Expected early exit, parsed %d lines", stats.LinesParsed)
 		}
 

--- a/pkg/logparser/parser.go
+++ b/pkg/logparser/parser.go
@@ -14,12 +14,12 @@ type ParseMatch struct {
 // parseMatchCandidate represents a potential match that is currently being evaluated. It holds the state needed to evaluate the match and communicate with the main parsing loop.
 // It has a receiver channel for new lines to check against the rule, and a done channel to signal when the match evaluation is complete. The main parsing loop will manage the lifecycle of these candidates, including purging inactive ones and broadcasting new lines to them.
 type parseMatchCandidate struct {
-	Rule             *MatchRule
-	FirstLine        *LogLine
-	FinalLineNumber  int
-	LineChannel      chan *LogLine // Used for adding new log lines
-	AllLinesReceived bool          // Indicates if all lines have been received for this candidate
-	DoneChannel      chan struct{} // Used to signal that matcher finished
+	Rule            *MatchRule
+	FirstLine       *LogLine
+	FinalLineNumber int
+	LineChannel     chan *LogLine // Used for adding new log lines
+	AcceptingLines  bool          // Indicates if all lines have been received for this candidate
+	DoneChannel     chan struct{} // Used to signal that matcher finished
 }
 
 // LogLine is a single parsed line and its 1-based position in the source.
@@ -64,7 +64,12 @@ func purgeInactiveMatchCandidates(lineNumber int, matcherCandidates []*parseMatc
 
 func broadcastLogLine(line *LogLine, matchers []*parseMatchCandidate) {
 	for _, m := range matchers {
-		m.LineChannel <- line
+		if m.AcceptingLines && line.LineNumber <= m.FinalLineNumber {
+			m.LineChannel <- line
+		} else if m.AcceptingLines && line.LineNumber > m.FinalLineNumber {
+			close(m.LineChannel) // Reached maximum lines
+			m.AcceptingLines = false
+		}
 	}
 }
 

--- a/pkg/logparser/parser.go
+++ b/pkg/logparser/parser.go
@@ -40,19 +40,17 @@ func getNewParseMatches(c <-chan *ParseMatch) []*ParseMatch {
 	}
 }
 
-func purgeInactiveMatchCandidates(lineNumber int, matcherCandidates []*parseMatchCandidate) []*parseMatchCandidate {
+func purgeInactiveMatchCandidates(matcherCandidates []*parseMatchCandidate) []*parseMatchCandidate {
 	activeMatchers := []*parseMatchCandidate{}
 
 	for _, m := range matcherCandidates {
-		if lineNumber > m.FinalLineNumber {
-			close(m.LineChannel) // Reached maximum lines
-			m.AllLinesReceived = true
-		}
 		// If the matcher is done, don't add it to the active matchers list and close its channel.
 		select {
 		case <-m.DoneChannel:
-			close(m.LineChannel) // Matcher is done
-			m.AllLinesReceived = true
+			if m.AcceptingLines {
+				close(m.LineChannel) // Ensure the line channel is closed if the matcher is done but still accepting lines
+				m.AcceptingLines = false
+			}
 			continue
 		default:
 			activeMatchers = append(activeMatchers, m)
@@ -105,6 +103,7 @@ func matchLineAgainstFirstChecks(line *LogLine, rules []*MatchRule) []*parseMatc
 func createMatchCandidate(firstLine *LogLine, rule *MatchRule) *parseMatchCandidate {
 	return &parseMatchCandidate{
 		LineChannel:     make(chan *LogLine, rule.getNeededLineCount()),
+		AcceptingLines:  true,
 		DoneChannel:     make(chan struct{}),
 		Rule:            rule,
 		FirstLine:       firstLine,

--- a/pkg/logparser/parser.go
+++ b/pkg/logparser/parser.go
@@ -14,11 +14,12 @@ type ParseMatch struct {
 // parseMatchCandidate represents a potential match that is currently being evaluated. It holds the state needed to evaluate the match and communicate with the main parsing loop.
 // It has a receiver channel for new lines to check against the rule, and a done channel to signal when the match evaluation is complete. The main parsing loop will manage the lifecycle of these candidates, including purging inactive ones and broadcasting new lines to them.
 type parseMatchCandidate struct {
-	Rule            *MatchRule
-	FirstLine       *LogLine
-	FinalLineNumber int
-	LineChannel     chan *LogLine // Used for adding new log lines
-	DoneChannel     chan struct{} // Used to signal that matcher finished
+	Rule             *MatchRule
+	FirstLine        *LogLine
+	FinalLineNumber  int
+	LineChannel      chan *LogLine // Used for adding new log lines
+	AllLinesReceived bool          // Indicates if all lines have been received for this candidate
+	DoneChannel      chan struct{} // Used to signal that matcher finished
 }
 
 // LogLine is a single parsed line and its 1-based position in the source.
@@ -45,12 +46,13 @@ func purgeInactiveMatchCandidates(lineNumber int, matcherCandidates []*parseMatc
 	for _, m := range matcherCandidates {
 		if lineNumber > m.FinalLineNumber {
 			close(m.LineChannel) // Reached maximum lines
-			continue
+			m.AllLinesReceived = true
 		}
 		// If the matcher is done, don't add it to the active matchers list and close its channel.
 		select {
 		case <-m.DoneChannel:
 			close(m.LineChannel) // Matcher is done
+			m.AllLinesReceived = true
 			continue
 		default:
 			activeMatchers = append(activeMatchers, m)

--- a/pkg/logparser/parser_test.go
+++ b/pkg/logparser/parser_test.go
@@ -53,29 +53,45 @@ func TestNewMatcher(t *testing.T) {
 }
 
 func TestBroadcastLogLine_BroadcastsToActiveChannels(t *testing.T) {
-	Rule := MatchRule{Checks: []LineCheck{{Contains: "Hi"}}} // Rule with at least 1 check so line channel has a buffer
-	m1 := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
-	m2 := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
-	m3 := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
+	r1 := MatchRule{Checks: []LineCheck{{Contains: "Hi"}, {Contains: "Hello"}}}
+	m1 := createMatchCandidate(&LogLine{LineNumber: 1}, &r1)
+	m2 := createMatchCandidate(&LogLine{LineNumber: 1}, &r1)
+
+	// These matchers will be testing the final line number logic.
+	r2 := MatchRule{Checks: []LineCheck{{Contains: "Hi"}}, MaxLines: 1}
+	m3 := createMatchCandidate(&LogLine{LineNumber: 1}, &r2)
+	m4 := createMatchCandidate(&LogLine{LineNumber: 1}, &r2)
 
 	// Close the line channel for m3 to simulate a matcher that has received all its lines. This will panic if broadcastLogLine tries to send to it, which is what we want to test against.
 	close(m3.LineChannel)
-	m3.AllLinesReceived = true
+	m3.AcceptingLines = false
 
-	matchers := []*parseMatchCandidate{m1, m2, m3}
+	matchers := []*parseMatchCandidate{m1, m2, m3, m4}
 
-	broadcastLogLine(&LogLine{Content: "Hi"}, matchers)
+	broadcastLogLine(&LogLine{Content: "Hi", LineNumber: 2}, matchers)
 
-	for range 2 {
+	if m4.AcceptingLines != false {
+		t.Fatal("Matcher should have AcceptingLines set to false after reaching FinalLineNumber")
+	}
+
+	for range 3 {
 		select {
-		case msg := <-m1.LineChannel:
-			if msg.Content != "Hi" {
+		case msg, ok := <-m1.LineChannel:
+			if !ok {
+				t.Fatal("Channel was closed when it should be open")
+			} else if msg.Content != "Hi" {
 				t.Fatalf("Expected message Hi got %v", msg.Content)
 			}
 
-		case msg := <-m2.LineChannel:
-			if msg.Content != "Hi" {
+		case msg, ok := <-m2.LineChannel:
+			if !ok {
+				t.Fatal("Channel was closed when it should be open")
+			} else if msg.Content != "Hi" {
 				t.Fatalf("Expected message Hi got %v", msg.Content)
+			}
+		case _, ok := <-m4.LineChannel:
+			if ok {
+				t.Fatal("Channel was open when it should be closed after reaching FinalLineNumber")
 			}
 		default:
 			t.Fatalf("Expected 2 messages on both channels, defaulted instead.")

--- a/pkg/logparser/parser_test.go
+++ b/pkg/logparser/parser_test.go
@@ -80,22 +80,35 @@ func TestBroadcastLogLine_BroadcastsToActiveChannels(t *testing.T) {
 }
 
 func TestPurgeInactiveMatchers(t *testing.T) {
-	Rule := MatchRule{}
+	Rule := MatchRule{
+		MaxLines: 2,
+		Checks: []LineCheck{
+			{Contains: "Hi"},
+			{Contains: "Hello"},
+		},
+	} // Rule with MaxLines so that we can test purging based on line number
 
+	// Expired because first line number is 1 and current line number is 5
 	expiredMatcher := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
+
 	closedMatcher := createMatchCandidate(&LogLine{LineNumber: 17}, &Rule)
 	close(closedMatcher.DoneChannel)
-	m := createMatchCandidate(&LogLine{LineNumber: 17}, &Rule)
+
+	m := createMatchCandidate(&LogLine{LineNumber: 3}, &Rule)
 
 	ams := []*parseMatchCandidate{expiredMatcher, closedMatcher, m}
 
-	r := purgeInactiveMatchCandidates(5, ams)
+	r := purgeInactiveMatchCandidates(4, ams)
 
-	if len(r) != 1 {
-		t.Fatalf("Expected 1 matcher got %v", len(r))
+	if len(r) != 2 {
+		t.Fatalf("Expected 2 matchers got %v", len(r))
 	}
-
-	if r[0] != m {
+	if r[0] != expiredMatcher {
+		t.Fatalf("Matcher is not correct, should be expiredMatcher")
+	} else if r[0].AllLinesReceived == false {
+		t.Fatal("Expired matcher should have AllLinesReceived set to true")
+	}
+	if r[1] != m {
 		t.Fatalf("Matcher is not correct, should be matcher")
 	}
 }

--- a/pkg/logparser/parser_test.go
+++ b/pkg/logparser/parser_test.go
@@ -101,36 +101,42 @@ func TestBroadcastLogLine_BroadcastsToActiveChannels(t *testing.T) {
 }
 
 func TestPurgeInactiveMatchers(t *testing.T) {
-	Rule := MatchRule{
-		MaxLines: 2,
-		Checks: []LineCheck{
-			{Contains: "Hi"},
-			{Contains: "Hello"},
-		},
-	} // Rule with MaxLines so that we can test purging based on line number
+	Rule := MatchRule{}
 
-	// Expired because first line number is 1 and current line number is 5
-	expiredMatcher := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
-
+	// This matcher will have a closed line and done channel, simulating a matcher that has completed.
 	closedMatcher := createMatchCandidate(&LogLine{LineNumber: 17}, &Rule)
 	close(closedMatcher.DoneChannel)
+	close(closedMatcher.LineChannel)
+	closedMatcher.AcceptingLines = false
+
+	// earlyFinishMatcher will have a closed done channel but an open line channel, simulating a matcher that has been signaled to stop but hasn't finished yet
+	// or a matcher that has matched before the final line was reached and is no longer accepting lines but hasn't been purged yet.
+	earlyFinishMatcher := createMatchCandidate(&LogLine{LineNumber: 17}, &Rule)
+	close(earlyFinishMatcher.DoneChannel)
 
 	m := createMatchCandidate(&LogLine{LineNumber: 3}, &Rule)
 
-	ams := []*parseMatchCandidate{expiredMatcher, closedMatcher, m}
+	ams := []*parseMatchCandidate{earlyFinishMatcher, closedMatcher, m}
 
-	r := purgeInactiveMatchCandidates(4, ams)
+	r := purgeInactiveMatchCandidates(ams)
 
-	if len(r) != 2 {
-		t.Fatalf("Expected 2 matchers got %v", len(r))
+	if len(r) != 1 {
+		t.Fatalf("Expected 1 matchers got %v", len(r))
 	}
-	if r[0] != expiredMatcher {
-		t.Fatalf("Matcher is not correct, should be expiredMatcher")
-	} else if r[0].AllLinesReceived == false {
-		t.Fatal("Expired matcher should have AllLinesReceived set to true")
-	}
-	if r[1] != m {
+	if r[0] != m {
 		t.Fatalf("Matcher is not correct, should be matcher")
+	}
+
+	if earlyFinishMatcher.AcceptingLines != false {
+		t.Fatal("Expected earlyFinishMatcher to have AcceptingLines set to false")
+	}
+	select {
+	case _, ok := <-earlyFinishMatcher.LineChannel:
+		if ok {
+			t.Fatal("Expected earlyFinishMatcher LineChannel to be closed")
+		}
+	default:
+		t.Fatal("Expected to select on earlyFinishMatcher LineChannel")
 	}
 }
 

--- a/pkg/logparser/parser_test.go
+++ b/pkg/logparser/parser_test.go
@@ -56,8 +56,13 @@ func TestBroadcastLogLine_BroadcastsToActiveChannels(t *testing.T) {
 	Rule := MatchRule{Checks: []LineCheck{{Contains: "Hi"}}} // Rule with at least 1 check so line channel has a buffer
 	m1 := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
 	m2 := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
+	m3 := createMatchCandidate(&LogLine{LineNumber: 1}, &Rule)
 
-	matchers := []*parseMatchCandidate{m1, m2}
+	// Close the line channel for m3 to simulate a matcher that has received all its lines. This will panic if broadcastLogLine tries to send to it, which is what we want to test against.
+	close(m3.LineChannel)
+	m3.AllLinesReceived = true
+
+	matchers := []*parseMatchCandidate{m1, m2, m3}
 
 	broadcastLogLine(&LogLine{Content: "Hi"}, matchers)
 


### PR DESCRIPTION
This pull request improves the efficiency and correctness of the log parsing logic, particularly around managing matcher lifecycles and resource cleanup. The main focus is on ensuring that matchers stop receiving lines at the right time, channels are closed safely, and unnecessary lines are not read or processed, which leads to better performance and reliability. The test suite is also enhanced to verify these behaviors.

**Matcher lifecycle management and efficiency:**

* Added an `AcceptingLines` boolean to `parseMatchCandidate` to explicitly track whether a matcher should continue receiving lines, preventing attempts to send to closed channels and ensuring channels are closed exactly once when done. [[1]](diffhunk://#diff-495fb85a3669c496172bdcfdee2577351886d649b8c83004d6db1d9032c850ddR21) [[2]](diffhunk://#diff-495fb85a3669c496172bdcfdee2577351886d649b8c83004d6db1d9032c850ddL42-R53) [[3]](diffhunk://#diff-495fb85a3669c496172bdcfdee2577351886d649b8c83004d6db1d9032c850ddR65-R70) [[4]](diffhunk://#diff-495fb85a3669c496172bdcfdee2577351886d649b8c83004d6db1d9032c850ddR106) [[5]](diffhunk://#diff-a85e315c21e75c19ffb1638fa3a32d67c4e1a8395f0d5d12e966c7e4a566b666R178-R181)
* Updated `broadcastLogLine` to only send lines to matchers that are still accepting lines and to close the channel and set `AcceptingLines` to false when their maximum line is reached.
* Refactored `purgeInactiveMatchCandidates` to remove the dependency on line numbers, instead relying on matcher state, and to safely close channels and update `AcceptingLines` when a matcher is done. [[1]](diffhunk://#diff-495fb85a3669c496172bdcfdee2577351886d649b8c83004d6db1d9032c850ddL42-R53) [[2]](diffhunk://#diff-a85e315c21e75c19ffb1638fa3a32d67c4e1a8395f0d5d12e966c7e4a566b666L226-R228)
* In the main parser loop, added logic to wait for matchers that are no longer accepting lines to finish and report errors if they do not exit in a timely manner, improving resource management and robustness.

**Test improvements:**

* Enhanced tests to verify that matchers do not receive lines after they should stop, that channels are closed appropriately, and that the parser does not process more lines than necessary, including a new test that runs on a single core to catch inefficiencies. [[1]](diffhunk://#diff-5dd9dd35eda354b501332f1b8d1906cab34770835377c6bbb800da5949a80661L56-R95) [[2]](diffhunk://#diff-5dd9dd35eda354b501332f1b8d1906cab34770835377c6bbb800da5949a80661L85-R140) [[3]](diffhunk://#diff-85c4904de1b244132360d7c6e8b04a6c0d75f8d1a5c36ac19e4a5d94e3460e88R6) [[4]](diffhunk://#diff-85c4904de1b244132360d7c6e8b04a6c0d75f8d1a5c36ac19e4a5d94e3460e88R241-R280)

These changes together make the log parser more efficient, safer, and easier to reason about, especially under concurrent workloads.